### PR TITLE
- adds extension method to get the resource URL

### DIFF
--- a/src/Extensions/BaseRequestBuilderExtensions.cs
+++ b/src/Extensions/BaseRequestBuilderExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Graph;
+using System;
+using System.Linq;
+
+namespace Graph.Community.Extensions
+{
+    public static class BaseRequestBuilderExtensions
+    {
+        private const char slash = '/';
+        private const int segmentsToSkip = 3; // [https, graph.microsoft.com, version]
+        /// <summary>
+        /// Returns the URL to use for the Resource property of Subscription object when creating a new subscription
+        /// </summary>
+        /// <param name="requestBuilder">Current request builder</param>
+        /// <returns>URL to use for the Resource property of Subscription object when creating a new subscription</returns>
+        public static string GetSubscriptionResourceUrl(this IBaseRequestBuilder requestBuilder) => 
+            $"{slash}{requestBuilder.RequestUrl.Split(new char[] { slash }, StringSplitOptions.RemoveEmptyEntries).Skip(segmentsToSkip).Aggregate((x, y) => $"{x}{slash}{y}")}";
+    }
+}

--- a/src/Extensions/BaseRequestBuilderExtensions.cs
+++ b/src/Extensions/BaseRequestBuilderExtensions.cs
@@ -6,14 +6,15 @@ namespace Graph.Community.Extensions
 {
     public static class BaseRequestBuilderExtensions
     {
-        private const char slash = '/';
-        private const int segmentsToSkip = 3; // [https, graph.microsoft.com, version]
         /// <summary>
-        /// Returns the URL to use for the Resource property of Subscription object when creating a new subscription
+        /// Returns the Path to use for the Resource property of Subscription object when creating a new subscription
         /// </summary>
         /// <param name="requestBuilder">Current request builder</param>
         /// <returns>URL to use for the Resource property of Subscription object when creating a new subscription</returns>
-        public static string GetSubscriptionResourceUrl(this IBaseRequestBuilder requestBuilder) => 
-            $"{slash}{requestBuilder.RequestUrl.Split(new char[] { slash }, StringSplitOptions.RemoveEmptyEntries).Skip(segmentsToSkip).Aggregate((x, y) => $"{x}{slash}{y}")}";
+        public static string GetResourceSubscriptionPath(this IBaseRequestBuilder requestBuilder)
+        {
+            var pathAndQuery = new Uri(requestBuilder.RequestUrl).PathAndQuery;
+            return pathAndQuery.Substring(pathAndQuery.IndexOf('/', 1)); //skips first / to ignore the version
+        }
     }
 }


### PR DESCRIPTION
This enables the following scenario
```CSharp
var sub = new Subscription
            {
                ChangeType = "created,updated",
                NotificationUrl = config.Ngrok + "/api/notifications",
                Resource = graphServiceClient.Teams["01b4b70e-2ea6-432f-a3d7-eefd826c2a8e"].Channels["19:81cf89b7ecef4e7994a84ee2cfb3248a@thread.skype"].Messages.GetSubscriptionResourcePath(),
                ExpirationDateTime = DateTime.UtcNow.AddMinutes(60),
                ClientState = "SecretClientState",
                IncludeResourceData = true,
            };
```
instead of
```CSharp
var sub = new Subscription
            {
                ChangeType = "created,updated",
                NotificationUrl = config.Ngrok + "/api/notifications",
                Resource = "/teams/01b4b70e-2ea6-432f-a3d7-eefd826c2a8e/channels/19:81cf89b7ecef4e7994a84ee2cfb3248a@thread.skype/messages",
                ExpirationDateTime = DateTime.UtcNow.AddMinutes(60),
                ClientState = "SecretClientState",
                IncludeResourceData = true,
            };
```
Thus creating a consistent experience where developers using the SDK do not need to know the path of resources to create subscriptions