### PR TITLE
Add CODEOWNERS with msgraph-sdk-dotnet-contrib-write

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @microsoftgraph/msgraph-sdk-dotnet-contrib-write


### PR DESCRIPTION
I've removed all individual access grants. All write access now goes through https://github.com/orgs/microsoftgraph/teams/msgraph-sdk-dotnet-contrib-write team. Please manage code owners through this team.

Admin settings now require JIT admin grant elevation through the Open Source Management Portal.